### PR TITLE
New SAMD51 ADC functions.

### DIFF
--- a/include/BareCpper/ATsamd/AnalogToDigitalConverter_ATsamd5x.hpp
+++ b/include/BareCpper/ATsamd/AnalogToDigitalConverter_ATsamd5x.hpp
@@ -135,16 +135,11 @@ namespace BareCpper
 				 /*
 				  * ADC conversion time = Sampling time + <ADC resolution> * CLK_ADC
 				  * 
-				  * Sampling time should be chosen based on the following formula
-				  * (54.10.4 Analog-to-Digital Converter (ADC) Characteristics, p.1800 in the datasheet)
+				  * CLK_ADC is set to 48 MHz / 64 = 750 kHz (period of 1.333... us),
+				  * The default sampling time to 54 * CLK_ADC = 72 us.
 				  * 
-				  * tsamplehold >= (Rsample + Rsource) x Csample x 9.7
-				  * 
-				  * We can set CLK_ADC to 48 MHz / 64 = 750 kHz (period of 1.333... us),
-				  * the sampling time to 54 * CLK_ADC = 72 us.
-				  * 
-				  * Assuming 12-bit resolution.
-				  * One conversion will be done in 72 + 12 * 1.333 = 88 us.
+				  * Assuming 12-bit resolution,
+				  * one conversion will be done in 72 + 12 * 1.333 = 88 us.
 				 */
 				if constexpr (adcIndex == 0)
 				{
@@ -258,6 +253,15 @@ namespace BareCpper
 				while(adcInstance_->SYNCBUSY.reg & ADC_SYNCBUSY_AVGCTRL);  //wait for sync
 			}
 
+			/**
+			 * @brief Change the sampling time.
+			 * Sampling time should be chosen based on the following formula
+			 * (54.10.4 Analog-to-Digital Converter (ADC) Characteristics, p.1800 in the datasheet)
+			 * 
+			 * tsamplehold >= (Rsample + Rsource) x Csample x 9.7
+			 * 
+			 * @param samplingTimeUs The sampling time, in us
+			 */
 			void setSamplingTime(const float samplingTimeUs)
 			{
 				static constexpr float clkPeriodUs = 64/48; //< ADC clk period in us, prescaler is 64, generator freq is 48 MHz

--- a/include/BareCpper/ATsamd/AnalogToDigitalConverter_ATsamd5x.hpp
+++ b/include/BareCpper/ATsamd/AnalogToDigitalConverter_ATsamd5x.hpp
@@ -6,6 +6,7 @@
 #endif
 
 #include <array>
+#include <cmath>
 #include "../AnalogToDigitalConverter.hpp"
 #include <sam.h>
 #if __has_include(<component-version.h>) 
@@ -50,7 +51,7 @@ namespace BareCpper
 		};
 
 		/**
-		 * @brief Supported voltage references for the ADC
+		 * Supported voltage references for the ADC
 		*/
 		enum class ADCreference : uint32_t
 		{
@@ -64,6 +65,26 @@ namespace BareCpper
 			Internal2V5 = SUPC_VREF_SEL_2V4_Val,
 			Internal1V65 = ADC_REFCTRL_REFSEL_INTVCC0_Val,
 			Internal3V3 = ADC_REFCTRL_REFSEL_INTVCC1_Val
+		};
+
+		/**
+		 * Number of samples to average
+		 * when using averaging mode.
+		 * 
+		 */
+		enum class ADCaverage : uint32_t
+		{
+			Samples1		=	0,
+			Samples2		=	1,
+			Samples4		=	2,
+			Samples8		=	3,
+			Samples16		=	4,
+			Samples32		=	5,
+			Samples64		=	6,
+			Samples128	=	7,
+			Samples256	=	8,
+			Samples512	=	9,
+			Samples1024	=	10
 		};
 
 		/**
@@ -114,16 +135,10 @@ namespace BareCpper
 				 /*
 				  * ADC conversion time = Sampling time + <ADC resolution> * CLK_ADC
 				  * 
-				  * Sampling time is chosen based on the following formula
+				  * Sampling time should be chosen based on the following formula
 				  * (54.10.4 Analog-to-Digital Converter (ADC) Characteristics, p.1800 in the datasheet)
 				  * 
 				  * tsamplehold >= (Rsample + Rsource) x Csample x 9.7
-				  * 
-				  * Rsample is 2kOhms and Csample is 3 pF, in the worst case, Rsource is the output impedance
-				  * of the op-amp circuit, in the op-amp linear range it is negligible, we obtain
-				  * tsamlehold >= 60 ns.
-				  * !!!!!!!!!!! SOMETHING IS MISSING, IT IS NOT WORKING AS IT SHOULD BE USING THIS RESULT !!!!!!!!!!!!!!
-				  * !!!!!!!!!!! Maybe the op-amp saturating !!!!!!!!!!!!
 				  * 
 				  * We can set CLK_ADC to 48 MHz / 64 = 750 kHz (period of 1.333... us),
 				  * the sampling time to 54 * CLK_ADC = 72 us.
@@ -148,25 +163,15 @@ namespace BareCpper
 				adcInstance_->CTRLA.bit.SWRST = 1;
 				while (adcInstance_->CTRLA.bit.SWRST);
 
-				// Set voltage reference to 2.5 V
-				setVoltageReference(ADCreference::Internal2V5);
-
-				// change to old reference (1.65 V)
-				// setVoltageReference(ADCreference::Internal1V65);
-
-				//// enable 4 samples averaging
-				// adcInstance_->AVGCTRL.reg = ADC_AVGCTRL_SAMPLENUM_4 |    // N oversampling
-				// ADC_AVGCTRL_ADJRES(0x2);   // Adjusting result to be 12bits as before
-
-				// while(adcInstance_->SYNCBUSY.reg & ADC_SYNCBUSY_AVGCTRL);  //wait for sync
+				// Set voltage reference to 3.3 V
+				setVoltageReference(ADCreference::Internal3V3);
 
 				// Set the clock divider
 				adcInstance_->CTRLA.bit.PRESCALER = ADC_CTRLA_PRESCALER_DIV64_Val;
 
-				// Set the sampling time
-				adcInstance_->SAMPCTRL.bit.SAMPLEN = 53;
-				// Wait for synchronization
-				while (adcInstance_->SYNCBUSY.bit.SAMPCTRL);
+				// Set the sampling time to 72 us
+				static constexpr float defaultSamplingTimeUs = 72.0f;
+				setSamplingTime(defaultSamplingTimeUs);
 
 				// Set the ADC resolution
 				setResolution(resolution);
@@ -238,6 +243,29 @@ namespace BareCpper
 				{
 					enable();
 				}
+			}
+
+			/**
+			 * @brief Set the number of samples to average
+			 * 
+			 * @param numSamples The number of samples to average
+			 */
+			void setNumberSamplesAveraging(const ADCaverage& numSamples)
+			{
+				uint16_t adjRes = getAdjRes(static_cast<uint16_t>(numSamples));
+				adcInstance_->AVGCTRL.reg = ADC_AVGCTRL_SAMPLENUM(static_cast<uint16_t>(numSamples))
+																	|	ADC_AVGCTRL_ADJRES(adjRes);
+				while(adcInstance_->SYNCBUSY.reg & ADC_SYNCBUSY_AVGCTRL);  //wait for sync
+			}
+
+			void setSamplingTime(const float samplingTimeUs)
+			{
+				static constexpr float clkPeriodUs = 64/48; //< ADC clk period in us, prescaler is 64, generator freq is 48 MHz
+				if(samplingTimeUs < clkPeriodUs) return;
+				// SAMPCTRL = (SAMPLEN + 1)*CLK_ADC
+				adcInstance_->SAMPCTRL.bit.SAMPLEN = static_cast<uint8_t>(std::roundf(samplingTimeUs/clkPeriodUs)) - 1;
+				// Wait for synchronization
+				while (adcInstance_->SYNCBUSY.bit.SAMPCTRL);
 			}
 			
 			/**
@@ -322,8 +350,6 @@ namespace BareCpper
 				}
 			}
 
-
-
 			/**
 			 * @brief Enable conversion done interrupt
 			*/
@@ -393,6 +419,16 @@ namespace BareCpper
 					//@note Could wait here for sync, should be unecessary i.e. 
 					// while (adcInstance_->SYNCBUSY.bit.INPUTCTRL);
 					adcInstance_->SWTRIG.bit.START = 1;
+				}
+
+				static constexpr uint8_t getAdjRes(const uint16_t avgSampleNum)
+				{
+					uint8_t adjRes = 0;
+					if(avgSampleNum == 2) 			adjRes = 1;
+					else if(avgSampleNum == 4)	adjRes = 2;
+					else if(avgSampleNum == 8)	adjRes = 3;
+					else												adjRes = 4;
+					return adjRes;
 				}
 		};
 	}


### PR DESCRIPTION
Added new samd51 ADC functions:
- Function to set the number of samples to average.
- Function to set the sampling time, assuming fixed ADC clock of 750 kHz.