### PR TITLE
Added SAMD51 external interrupt controller.

### DIFF
--- a/include/BareCpper/ATsamd/ExternalInterruptController_ATsamd5x.hpp
+++ b/include/BareCpper/ATsamd/ExternalInterruptController_ATsamd5x.hpp
@@ -73,7 +73,7 @@ namespace BareCpper
           const bool shouldRestart = EIC->CTRLA.reg & EIC_CTRLA_ENABLE;
           if(shouldRestart) disable();
           // set the Pin alternative function to peripheral A (EIC)
-          BareCpper::gpioFunction(pin, ATsamd5x::Peripheral::A);
+          BareCpper::gpioFunction<PinT>(pin, std::optional<ATsamd5x::Peripheral>{ATsamd5x::Peripheral::A});
           // configure the EIC sense mode
           constexpr auto channel = PinT::id().pin;
           constexpr uint8_t configRegNum = (channel > 7);

--- a/include/BareCpper/ATsamd/ExternalInterruptController_ATsamd5x.hpp
+++ b/include/BareCpper/ATsamd/ExternalInterruptController_ATsamd5x.hpp
@@ -64,7 +64,7 @@ namespace BareCpper
         using CallbackT = std::function<void()>;
         
         template<typename PinT>
-        void attachInterrupt(const PinT& pin = PinT{}
+        void attachInterrupt(const PinT& pin
                             , const CallbackT& callback
                             , const ExternalInterruptSense& mode
                             , const ExternalInterruptDebouncer& debounce = ExternalInterruptDebouncer::Off)
@@ -100,13 +100,13 @@ namespace BareCpper
           // enable interrupt in EIC
           EIC->INTENSET.reg |= (0x1 << channel);
           // set callback
-          callbacks_[channel] = callback;
+          ExternalInterruptController::callbacks_[channel] = callback;
           // reenable EIC
           if(shouldRestart) enable();
         }
 
         template<typename PinT>
-        void detachInterrupt(const PinT& pin = PinT{})
+        void detachInterrupt(const PinT& pin)
         {
           // registers are enable-protected, disable EIC before configuring if it is enabled
           const bool shouldRestart = EIC->CTRLA.reg & EIC_CTRLA_ENABLE;
@@ -116,7 +116,7 @@ namespace BareCpper
           EIC->INTENCLR.reg |= (0x1 << channel);
           // disable interrupt in NVIC
           NVIC_DisableIRQ(IrqNumber);
-          callback_[channel] = nullptr;
+          ExternalInterruptController::callbacks_[channel] = nullptr;
           // reenable EIC
           if(shouldRestart) enable();
         }
@@ -162,7 +162,7 @@ namespace BareCpper
         static void IrqHandler(const uint8_t channel)
         {
           // call the callback function
-          if(callbacks_[channel]) callbacks_[channel];
+          if(ExternalInterruptController::callbacks_[channel]) ExternalInterruptController::callbacks_[channel];
           // clear the interrupt flag
           EIC->INTFLAG.reg |= (0x1 << channel);
         }

--- a/include/BareCpper/ATsamd/ExternalInterruptController_ATsamd5x.hpp
+++ b/include/BareCpper/ATsamd/ExternalInterruptController_ATsamd5x.hpp
@@ -101,7 +101,7 @@ namespace BareCpper
           NVIC_SetPriority(irqNumber, 0);
           NVIC_EnableIRQ(irqNumber);
           // enable interrupt in EIC
-          EIC->INTENSET.reg |= (0x1 << channel);
+          EIC->INTENSET.reg = (0x1 << channel);
           // set callback
           ExternalInterruptController::callbacks_[channel] = callback;
           // reenable EIC
@@ -117,7 +117,7 @@ namespace BareCpper
           constexpr auto channel = PinT::id().pin;
           constexpr auto irqNumber = getIrqNumber(channel);
           // disable interrupt in EIC
-          EIC->INTENCLR.reg |= (0x1 << channel);
+          EIC->INTENCLR.reg = (0x1 << channel);
           // disable interrupt in NVIC
           NVIC_DisableIRQ(irqNumber);
           ExternalInterruptController::callbacks_[channel] = nullptr;

--- a/include/BareCpper/ATsamd/ExternalInterruptController_ATsamd5x.hpp
+++ b/include/BareCpper/ATsamd/ExternalInterruptController_ATsamd5x.hpp
@@ -1,0 +1,178 @@
+#ifndef EXTERNAL_INTERRUPT_CONTROLLER_SAMD51_HPP
+#define EXTERNAL_INTERRUPT_CONTROLLER_SAMD51_HPP
+
+#if !__SAMD51__
+#  error "SAMD library error, please check and update accordingly."
+#endif
+
+#include <functional>
+
+#include "../Gpio.hpp"
+#include <sam.h>
+
+namespace BareCpper
+{
+  namespace SAMD51
+  {
+    /**
+     * Edge or level configuration for
+     * the external interrupt/event
+     * 
+     */
+    enum class ExternalInterruptSense : uint8_t
+    {
+      None  = 0x0,
+      Rise  = 0x1,
+      Fall  = 0x2,
+      Both  = 0x3,
+      High  = 0x4,
+      Low   = 0x5
+    };
+
+    enum class ExternalInterruptDebouncer : uint8_t
+    {
+      Off = 0xFF,
+      Prescaler2    = 0x0,
+      Prescaler4    = 0x1,
+      Prescaler8    = 0x2,
+      Prescaler16   = 0x3,
+      Prescaler32   = 0x4,
+      Prescaler64   = 0x5,
+      Prescaler128  = 0x6,
+      Prescaler256  = 0x7,
+    };
+
+    class ExternalInterruptController
+    {
+      public:
+        static constexpr uint8_t NumberChannels = 16;
+        /**
+         * Initialize the EIC
+         * 
+         */
+        void init()
+        {
+          // EIC MCLK is enabled by default
+          // Use GCLK0 for EIC
+          GCLK->PCHCTRL[EIC_GCLK_ID].reg = GCLK_PCHCTRL_GEN_GCLK0_Val | (1 << GCLK_PCHCTRL_CHEN_Pos);
+          // Wait for clock synchronization
+				  while (GCLK->SYNCBUSY.reg);
+          // Reset the EIC
+          reset();
+        }
+
+        using CallbackT = std::function<void()>;
+        
+        template<typename PinT>
+        void attachInterrupt(const PinT& pin = PinT{}
+                            , const CallbackT& callback
+                            , const ExternalInterruptSense& mode
+                            , const ExternalInterruptDebouncer& debounce = ExternalInterruptDebouncer::Off)
+        {
+          // registers are enable-protected, disable EIC before configuring if it is enabled
+          const bool shouldRestart = EIC->CTRLA.reg & EIC_CTRLA_ENABLE;
+          if(shouldRestart) disable();
+          // set the Pin alternative function to peripheral A (EIC)
+          BareCpper::gpioFunction(pin, ATsamd5x::Peripheral::A);
+          // configure the EIC sense mode
+          constexpr auto channel = PinT::id().pin;
+          constexpr uint8_t configRegNum = (channel > 7);
+          constexpr uint8_t configRegShift = (channel - 8*configRegNum) << 2; //< channel config starts at bit 4^channel
+          EIC->CONFIG[configRegNum].reg &= ~(0x7 << configRegShift);
+          EIC->CONFIG[configRegNum].reg |= (static_cast<uint8_t>(mode) << configRegShift);
+          // configure debouncer
+          if(debounce == ExternalInterruptDebouncer::Off)
+          {
+            EIC->DEBOUNCEN.reg &= ~(0x1 << channel);
+          }
+          else
+          {
+            constexpr uint8_t dpresclareRegShift = configRegNum << 2;  //< dpreslacer for pins 0-7 start at bit 0, for pins 8-15 at bit 4 (4^n)
+            // set debounce prescaler
+            EIC->DPRESCALER.reg &= ~(0x7 << dpresclareRegShift);
+            EIC->DPRESCALER.reg |= (static_cast<uint8_t>(debounce) << dpresclareRegShift);
+            EIC->DEBOUNCEN.reg |= (0x1 << channel);
+          }
+          // enable interrupt in NVIC
+          constexpr auto IrqNumber = getIrqNumber(channel);
+          NVIC_ClearPendingIRQ(IrqNumber);
+          NVIC_EnableIRQ(IrqNumber);
+          // enable interrupt in EIC
+          EIC->INTENSET.reg |= (0x1 << channel);
+          // set callback
+          callbacks_[channel] = callback;
+          // reenable EIC
+          if(shouldRestart) enable();
+        }
+
+        template<typename PinT>
+        void detachInterrupt(const PinT& pin = PinT{})
+        {
+          // registers are enable-protected, disable EIC before configuring if it is enabled
+          const bool shouldRestart = EIC->CTRLA.reg & EIC_CTRLA_ENABLE;
+          constexpr auto channel = PinT::id().pin;
+          constexpr auto IrqNumber = getIrqNumber(channel);
+          // disable interrupt in EIC
+          EIC->INTENCLR.reg |= (0x1 << channel);
+          // disable interrupt in NVIC
+          NVIC_DisableIRQ(IrqNumber);
+          callback_[channel] = nullptr;
+          // reenable EIC
+          if(shouldRestart) enable();
+        }
+
+        /**
+         * Enable the EIC
+         * 
+         */
+        void enable()
+        {
+          // enable EIC
+          EIC->CTRLA.reg |= EIC_CTRLA_ENABLE;
+          // wait for sync
+          while(EIC->SYNCBUSY.reg & EIC_SYNCBUSY_ENABLE);
+        }
+
+        /**
+         * Disable the EIC
+         * 
+         */
+        void disable()
+        {
+          // disable EIC
+          EIC->CTRLA.reg &= ~EIC_CTRLA_ENABLE;
+          // wait for sync
+          while(EIC->SYNCBUSY.reg & EIC_SYNCBUSY_ENABLE);
+        }
+
+        /**
+         * Software reset the EIC
+         * 
+         */
+        void reset()
+        {
+          EIC->CTRLA.reg |= EIC_CTRLA_SWRST;
+          while((EIC->CTRLA.reg & EIC_CTRLA_SWRST) && (EIC->SYNCBUSY.reg & EIC_SYNCBUSY_SWRST));
+        }
+
+        // callback function holders
+        static CallbackT callbacks_[NumberChannels];
+
+        // function to call inside EIC IRQ handlers
+        static void IrqHandler(const uint8_t channel)
+        {
+          // call the callback function
+          if(callbacks_[channel]) callbacks_[channel];
+          // clear the interrupt flag
+          EIC->INTFLAG.reg |= (0x1 << channel);
+        }
+      private:
+        static constexpr IRQn_Type getIrqNumber(const uint8_t channel)
+        {
+          return static_cast<IRQn_Type>(EIC_0_IRQn + channel);
+        }
+    };
+  }
+}
+
+#endif //EXTERNAL_INTERRUPT_CONTROLLER_SAMD51_HPP

--- a/include/BareCpper/ATsamd/ExternalInterruptController_ATsamd5x.hpp
+++ b/include/BareCpper/ATsamd/ExternalInterruptController_ATsamd5x.hpp
@@ -166,7 +166,7 @@ namespace BareCpper
         static void irqHandler(const uint8_t channel)
         {
           // call the callback function
-          if(ExternalInterruptController::callbacks_[channel]) ExternalInterruptController::callbacks_[channel];
+          if(ExternalInterruptController::callbacks_[channel]) ExternalInterruptController::callbacks_[channel]();
           // clear the interrupt flag
           EIC->INTFLAG.reg = (0x1 << channel);
         }

--- a/include/BareCpper/ATsamd/ExternalInterruptController_ATsamd5x.hpp
+++ b/include/BareCpper/ATsamd/ExternalInterruptController_ATsamd5x.hpp
@@ -114,7 +114,7 @@ namespace BareCpper
           // registers are enable-protected, disable EIC before configuring if it is enabled
           const bool shouldRestart = EIC->CTRLA.reg & EIC_CTRLA_ENABLE;
           if(shouldRestart) disable();
-          constexpr auto channel = PinT::id().pin;
+          constexpr auto channel = (PinT::id().pin > 15) ? (PinT::id().pin - 16) : PinT::id().pin;
           constexpr auto irqNumber = getIrqNumber(channel);
           // disable interrupt in EIC
           EIC->INTENCLR.reg = (0x1 << channel);

--- a/include/BareCpper/ATsamd/ExternalInterruptController_ATsamd5x.hpp
+++ b/include/BareCpper/ATsamd/ExternalInterruptController_ATsamd5x.hpp
@@ -52,7 +52,8 @@ namespace BareCpper
          */
         void init()
         {
-          // EIC MCLK is enabled by default
+          // Enable EIC MCLK
+          MCLK->APBAMASK.reg |= MCLK_APBAMASK_EIC;
           // Use GCLK1 for EIC (max is 100 MHz)
           GCLK->PCHCTRL[EIC_GCLK_ID].reg = GCLK_PCHCTRL_GEN_GCLK1_Val | (1 << GCLK_PCHCTRL_CHEN_Pos);
           // Wait for clock synchronization

--- a/include/BareCpper/ATsamd/ExternalInterruptController_ATsamd5x.hpp
+++ b/include/BareCpper/ATsamd/ExternalInterruptController_ATsamd5x.hpp
@@ -77,7 +77,7 @@ namespace BareCpper
           // set the Pin alternative function to peripheral A (EIC)
           BareCpper::gpioFunction<PinT>(pin, std::optional<ATsamd5x::Peripheral>{ATsamd5x::Peripheral::A});
           // configure the EIC sense mode
-          constexpr auto channel = PinT::id().pin;
+          constexpr auto channel = (PinT::id().pin > 15) ? (PinT::id().pin - 16) : PinT::id().pin;
           constexpr uint8_t configRegNum = (channel > 7);
           constexpr uint8_t configRegShift = (channel - 8*configRegNum) << 2; //< channel config starts at bit 4^channel
           EIC->CONFIG[configRegNum].reg &= ~(0x7 << configRegShift);

--- a/include/BareCpper/ATsamd/ExternalInterruptController_ATsamd5x.hpp
+++ b/include/BareCpper/ATsamd/ExternalInterruptController_ATsamd5x.hpp
@@ -53,8 +53,8 @@ namespace BareCpper
         void init()
         {
           // EIC MCLK is enabled by default
-          // Use GCLK0 for EIC
-          GCLK->PCHCTRL[EIC_GCLK_ID].reg = GCLK_PCHCTRL_GEN_GCLK0_Val | (1 << GCLK_PCHCTRL_CHEN_Pos);
+          // Use GCLK1 for EIC (max is 100 MHz)
+          GCLK->PCHCTRL[EIC_GCLK_ID].reg = GCLK_PCHCTRL_GEN_GCLK1_Val | (1 << GCLK_PCHCTRL_CHEN_Pos);
           // Wait for clock synchronization
 				  while (GCLK->SYNCBUSY.reg);
           // Reset the EIC

--- a/src/BareCpper/ATsamd/ExternalInterruptController_ATsamd5x.cpp
+++ b/src/BareCpper/ATsamd/ExternalInterruptController_ATsamd5x.cpp
@@ -1,0 +1,98 @@
+#if ARDUINO
+#include "BareCpper/include/BareCpper/ATsamd/ExternalInterruptController_ATsamd5x.hpp"
+#else
+#include "BareCpper/ATsamd/ExternalInterruptController_ATsamd5x.hpp"
+#endif
+
+namespace BareCpper
+{
+  namespace SAMD51
+  {
+    static typename ExternalInterruptController::CallbackT ExternalInterruptController::callbacks_[NumberChannels];
+  }
+}
+
+extern "C"
+{
+// define interrupt handlers
+void EIC_0_Handler()
+{
+  BareCpper::SAMD51::ExternalInterruptController::IrqHandler(0);
+}
+
+void EIC_1_Handler()
+{
+  BareCpper::SAMD51::ExternalInterruptController::IrqHandler(1);
+}
+
+void EIC_2_Handler()
+{
+  BareCpper::SAMD51::ExternalInterruptController::IrqHandler(2);
+}
+
+void EIC_3_Handler()
+{
+  BareCpper::SAMD51::ExternalInterruptController::IrqHandler(3);
+}
+
+void EIC_4_Handler()
+{
+  BareCpper::SAMD51::ExternalInterruptController::IrqHandler(4);
+}
+
+void EIC_5_Handler()
+{
+  BareCpper::SAMD51::ExternalInterruptController::IrqHandler(5);
+}
+
+void EIC_6_Handler()
+{
+  BareCpper::SAMD51::ExternalInterruptController::IrqHandler(6);
+}
+
+void EIC_7_Handler()
+{
+  BareCpper::SAMD51::ExternalInterruptController::IrqHandler(7);
+}
+
+void EIC_8_Handler()
+{
+  BareCpper::SAMD51::ExternalInterruptController::IrqHandler(8);
+}
+
+void EIC_9_Handler()
+{
+  BareCpper::SAMD51::ExternalInterruptController::IrqHandler(9);
+}
+
+void EIC_10_Handler()
+{
+  BareCpper::SAMD51::ExternalInterruptController::IrqHandler(10);
+}
+
+void EIC_11_Handler()
+{
+  BareCpper::SAMD51::ExternalInterruptController::IrqHandler(11);
+}
+
+void EIC_12_Handler()
+{
+  BareCpper::SAMD51::ExternalInterruptController::IrqHandler(12);
+}
+
+void EIC_13_Handler()
+{
+  BareCpper::SAMD51::ExternalInterruptController::IrqHandler(13);
+}
+
+void EIC_14_Handler()
+{
+  BareCpper::SAMD51::ExternalInterruptController::IrqHandler(14);
+}
+
+void EIC_15_Handler()
+{
+  BareCpper::SAMD51::ExternalInterruptController::IrqHandler(15);
+}
+
+}

--- a/src/BareCpper/ATsamd/ExternalInterruptController_ATsamd5x.cpp
+++ b/src/BareCpper/ATsamd/ExternalInterruptController_ATsamd5x.cpp
@@ -8,7 +8,7 @@ namespace BareCpper
 {
   namespace SAMD51
   {
-    typename ExternalInterruptController::CallbackT ExternalInterruptController::callbacks_[NumberChannels];
+    typename ExternalInterruptController::CallbackT ExternalInterruptController::callbacks_[ExternalInterruptController::NumberChannels];
   }
 }
 

--- a/src/BareCpper/ATsamd/ExternalInterruptController_ATsamd5x.cpp
+++ b/src/BareCpper/ATsamd/ExternalInterruptController_ATsamd5x.cpp
@@ -17,82 +17,82 @@ extern "C"
 // define interrupt handlers
 void EIC_0_Handler()
 {
-  BareCpper::SAMD51::ExternalInterruptController::IrqHandler(0);
+  BareCpper::SAMD51::ExternalInterruptController::irqHandler(0);
 }
 
 void EIC_1_Handler()
 {
-  BareCpper::SAMD51::ExternalInterruptController::IrqHandler(1);
+  BareCpper::SAMD51::ExternalInterruptController::irqHandler(1);
 }
 
 void EIC_2_Handler()
 {
-  BareCpper::SAMD51::ExternalInterruptController::IrqHandler(2);
+  BareCpper::SAMD51::ExternalInterruptController::irqHandler(2);
 }
 
 void EIC_3_Handler()
 {
-  BareCpper::SAMD51::ExternalInterruptController::IrqHandler(3);
+  BareCpper::SAMD51::ExternalInterruptController::irqHandler(3);
 }
 
 void EIC_4_Handler()
 {
-  BareCpper::SAMD51::ExternalInterruptController::IrqHandler(4);
+  BareCpper::SAMD51::ExternalInterruptController::irqHandler(4);
 }
 
 void EIC_5_Handler()
 {
-  BareCpper::SAMD51::ExternalInterruptController::IrqHandler(5);
+  BareCpper::SAMD51::ExternalInterruptController::irqHandler(5);
 }
 
 void EIC_6_Handler()
 {
-  BareCpper::SAMD51::ExternalInterruptController::IrqHandler(6);
+  BareCpper::SAMD51::ExternalInterruptController::irqHandler(6);
 }
 
 void EIC_7_Handler()
 {
-  BareCpper::SAMD51::ExternalInterruptController::IrqHandler(7);
+  BareCpper::SAMD51::ExternalInterruptController::irqHandler(7);
 }
 
 void EIC_8_Handler()
 {
-  BareCpper::SAMD51::ExternalInterruptController::IrqHandler(8);
+  BareCpper::SAMD51::ExternalInterruptController::irqHandler(8);
 }
 
 void EIC_9_Handler()
 {
-  BareCpper::SAMD51::ExternalInterruptController::IrqHandler(9);
+  BareCpper::SAMD51::ExternalInterruptController::irqHandler(9);
 }
 
 void EIC_10_Handler()
 {
-  BareCpper::SAMD51::ExternalInterruptController::IrqHandler(10);
+  BareCpper::SAMD51::ExternalInterruptController::irqHandler(10);
 }
 
 void EIC_11_Handler()
 {
-  BareCpper::SAMD51::ExternalInterruptController::IrqHandler(11);
+  BareCpper::SAMD51::ExternalInterruptController::irqHandler(11);
 }
 
 void EIC_12_Handler()
 {
-  BareCpper::SAMD51::ExternalInterruptController::IrqHandler(12);
+  BareCpper::SAMD51::ExternalInterruptController::irqHandler(12);
 }
 
 void EIC_13_Handler()
 {
-  BareCpper::SAMD51::ExternalInterruptController::IrqHandler(13);
+  BareCpper::SAMD51::ExternalInterruptController::irqHandler(13);
 }
 
 void EIC_14_Handler()
 {
-  BareCpper::SAMD51::ExternalInterruptController::IrqHandler(14);
+  BareCpper::SAMD51::ExternalInterruptController::irqHandler(14);
 }
 
 void EIC_15_Handler()
 {
-  BareCpper::SAMD51::ExternalInterruptController::IrqHandler(15);
+  BareCpper::SAMD51::ExternalInterruptController::irqHandler(15);
 }
 
 }

--- a/src/BareCpper/ATsamd/ExternalInterruptController_ATsamd5x.cpp
+++ b/src/BareCpper/ATsamd/ExternalInterruptController_ATsamd5x.cpp
@@ -8,7 +8,7 @@ namespace BareCpper
 {
   namespace SAMD51
   {
-    static typename ExternalInterruptController::CallbackT ExternalInterruptController::callbacks_[NumberChannels];
+    typename ExternalInterruptController::CallbackT ExternalInterruptController::callbacks_[NumberChannels];
   }
 }
 


### PR DESCRIPTION
- Asynchronous pin checking is not implemented.
- NMI is not implemented, but can be easily added if needed in the future.
- Uses GCLK1 = 48 MHz (GCLK0 is 120 MHz, which should be fine, but above the limit for f_EIC noted in the datasheet to be 100 MHz).